### PR TITLE
Test lumos automatically on multiple versions of python

### DIFF
--- a/.github/workflows/lumos-testing.yaml
+++ b/.github/workflows/lumos-testing.yaml
@@ -1,8 +1,6 @@
 name: Lumos Testing
 
 on:
-  push:
-    branches: [ test_python39 ]
   pull_request:
     types: [opened, synchronize]
     paths:
@@ -20,7 +18,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -48,7 +46,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install lumos dependencies

--- a/.github/workflows/lumos-testing.yaml
+++ b/.github/workflows/lumos-testing.yaml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-20.04, ubuntu-latest]
         python-version: ["3.8", "3.9","3.10"]
     runs-on: ${{ matrix.os }}
     steps:    
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/lumos-testing.yaml
+++ b/.github/workflows/lumos-testing.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize]
     paths:
       - '**.py'
+      - '**.yaml'
 
 jobs:
   Lumos-Testing-on-Linux:

--- a/.github/workflows/lumos-testing.yaml
+++ b/.github/workflows/lumos-testing.yaml
@@ -8,13 +8,14 @@ on:
       - '**.yaml'
 
 jobs:
-  Lumos-Testing-on-Linux:
-    runs-on: ubuntu-latest
+  Lumos-Testing:
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 4
       matrix:
+        os: [ubuntu-22.04, ubuntu-20.04,windows-latest]
         python-version: ["3.8", "3.9","3.10"]
+    runs-on: ${{ matrix.os }}
     steps:    
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -26,34 +27,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ./requirements.txt
-      - name: Install lumos as a development package
-        run: |
-          python setup.py develop
-      - name: Install pytest
-        run: |
-          pip install pytest
-      - name: Run tests with pytest
-        run: |
-          pytest -vs
-  
-  Lumos-Testing-on-Windows:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        python-version: ["3.8", "3.9","3.10"]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install lumos dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r .\requirements.txt
       - name: Install lumos as a development package
         run: |
           python setup.py develop

--- a/.github/workflows/lumos-testing.yaml
+++ b/.github/workflows/lumos-testing.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9","3.10"]
     steps:    
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9","3.10"]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/lumos-testing.yaml
+++ b/.github/workflows/lumos-testing.yaml
@@ -1,6 +1,8 @@
 name: Lumos Testing
 
 on:
+  push:
+    branches: [ test_python39 ]
   pull_request:
     types: [opened, synchronize]
     paths:

--- a/.github/workflows/lumos-testing.yaml
+++ b/.github/workflows/lumos-testing.yaml
@@ -11,9 +11,8 @@ jobs:
   Lumos-Testing:
     strategy:
       fail-fast: false
-      max-parallel: 4
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04,windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: ["3.8", "3.9","3.10"]
     runs-on: ${{ matrix.os }}
     steps:    


### PR DESCRIPTION
Initial version was tested on python 3.8
This change makes test run on 3.8,3.9,3.10 on linux and windows.

Each time a new pull request will be made, lumos setup and testing will be executed on the 3 python versions